### PR TITLE
Update zh-TW translation (Re-open)

### DIFF
--- a/phira/locales/zh-TW/profile.ftl
+++ b/phira/locales/zh-TW/profile.ftl
@@ -2,8 +2,18 @@
 logout = 登出
 logged-out = 您已登出
 
+delete = 刪除帳戶
+delete-failed = 刪除帳戶失敗
+delete-req-sent = 帳戶刪除請求已提交
+
 load-user-failed = 載入使用者資訊失敗
 edit-avatar-success = 頭像已更新
 edit-avatar-failed = 上傳頭像失敗
 
 uploading-avatar = 頭像上傳中...
+
+load-record-failed = 載入遊玩紀錄失敗
+
+last-login = 上次登入於：{ $time }
+badge-admin = 管理員
+badge-sponsor = 贊助者

--- a/phira/locales/zh-TW/settings.ftl
+++ b/phira/locales/zh-TW/settings.ftl
@@ -17,6 +17,8 @@ item-mp-addr-sub = 伺服器地址，'主機位址:埠號'
 item-mp-addr-invalid = 無效的伺服器地址
 item-lowq = 低畫質模式
 item-lowq-sub = 建議在畫面卡頓時啟用
+item-insecure = 不安全模式
+item-insecure-sub = 當無法使用在線功能時可嘗試該功能。這會使得你的連線不安全！
 
 item-adjust = 自動對齊時間
 item-adjust-sub = 自動調整延遲以同步音樂和譜面
@@ -50,3 +52,6 @@ about-content =
 
   BiliBili 帳號：@Phira官方
   QQ 頻道：r48eajexth
+
+  感謝以下玩家對我們的支持！（按字典序排序）
+  -哎喂哟-, 114514opkl, 123165, 341819481, 43167364miku, AEsir, Afterglow, akuanoneko, amstlkqp, ApecY176, Arashi, Ark小周, Aromq, Atariter, Aurora., Avencess, Bigironpig, Bradish, brightquasar, buguwu, ccw., CH06E01, CQBZ, Dagehoo, DongZheng, dslzhz, Dumbledore防重复, Ehdiwhxishs, Enigma, evmb, Fall_Li_distance, flamo, Fly段某, Gentle Emperor, GR-17, GYuuLT, Hen77777Tai, hibikip3p, huahbas, huanle, humosu, icyfish, Jerry24, Jiangling, jike, Kaji Emperor, KevinJame1, KKZN, KQ_KongQi, KRYSGCJ, Kynovter, LemonKnife, Lh_39_master, Lighear, liminghao, Lin124, Lio_the_Fox, LJMSTKZF, lorac, luftsch1oss, Maedey, mancy, MaxJack, MGRB, Miku.official, Miska1123, MSSkn, NaiTaGQ, NananEbina, nanxiangx, NEROILY, NingNing0721, NoChoco, Nothu, NsdrfChkew, O-DouSan, obsession, pgwcm, Phira-一个随意废物, PopCatNya, QAQwhatever, QingF_青枫, qwer0160, QWQYuRin, rainbowbex, Ransen, Reeslith, Requiem, RinceTacroix, Rinorsi, Rpec, RUNFORFUNQAQ, sbcujbj, Sensant, Shaaadowsong, Sixi, sksks, Sky_Frozen, soppi, Tearout, Tesla T-T, Thunderlis, Tigerzzz, Tixbicg, Tony0703, Ulyssses, Wind_And_Sky, wjxwp, wszyj, WuJi, wylwktd, xiaoqian, xiaozhemu, XOO_cookie, Xr888, yang125, YMiiiiiii, YN呓凝, YT_XT, yulilizi, yyyyyylll, ZERO707, Zips, ほしの アイ, 一片普通的茶叶, 三月鸠, 不会玩音游的屑, 久往大魔王, 乙酸乙烯酯, 二货甜鱼, 傲丙初A1bcu, 冷光_Lumine, 华树邶, 四十四次日落, 城边的一朵云, 天启之云, 如月清风, 小懒max, 小鲁班, 幻枫落晨, 御坂13900号, 心兮可念, 悲伤很菜, 我永远喜欢爱莉希雅, 日暖随安, 早安起不早, 明晓破风, 易阳Easy_sun, 晨曜, 曲奇cookies, 望悅不是月, 林江恒, 柒柒柒柒, 梓川川川川川川, 欧皇本蝗, 残风, 洛尘sama, 灵晨没有准度, 炫金创创鹅, 甘城猫猫猫猫, 男德村村西张寡妇, 白衣炫五月, 老王, 芝士土拨鼠, 若笛, 荷叶鸭腿, 落弦winglow, 落痕luor, 逐潘, 邮疣铀, 银酱, 露西亚是我的, 飞驰的压路机, 骁龙750G

--- a/phira/locales/zh-TW/song.ftl
+++ b/phira/locales/zh-TW/song.ftl
@@ -74,6 +74,9 @@ info-rating = 評分
 info-type = 種類
 info-tags = 標籤
 
+reviewed = 已審核
+unreviewed = 未審核
+
 review-approve = 通過
 review-deny = 拒絕
 review-del = 從在線刪除

--- a/prpr/locales/zh-TW/chart_info.ftl
+++ b/prpr/locales/zh-TW/chart_info.ftl
@@ -24,4 +24,4 @@ intro = 簡介
 tags = 標籤
 tag-exists = 標籤已存在
 
-illegal-input = 輸入非法
+illegal-input = 非法輸入


### PR DESCRIPTION
本PR包含自 651c7a358f695fd321272495e3fd09084eb45f19 至 e0984bbe11d88d351eb9650fedd6525a9f183b5f 的翻譯更新

### 規則新增
- **最近**登**录**：{ $time } -> **上次**登**入於**：{ $time } 
- 輸入非法 -> 非法輸入
> **Note**
> 見 #113 

### 待定
`parser.ftl` 等標點符號(冒號、括號)之全半形統一

<sub>看來以後要小心全域取代了</sub>

(Original: #117)
