### PR TITLE
Update zh-TW translation

### DIFF
--- a/phira/locales/zh-TW/common.ftl
+++ b/phira/locales/zh-TW/common.ftl
@@ -15,3 +15,10 @@ chart-special = 特殊
 chart-unstable = 未上架
 
 list-empty = 空空如也
+
+tos-and-policy = 《服務條款》和《隱私政策》
+tos-and-policy-desc = 在使用由 TeamFlos 提供的 Phira 線上服務部分之前，你必須閱讀並同意我們的《服務條款》和《隱私政策》。
+tos = 服務條款
+policy = 隱私政策
+
+open-in-web = 在網站中打開

--- a/phira/locales/zh-TW/common.ftl
+++ b/phira/locales/zh-TW/common.ftl
@@ -17,8 +17,8 @@ chart-unstable = 未上架
 list-empty = 空空如也
 
 tos-and-policy = 《服務條款》和《隱私政策》
-tos-and-policy-desc = 在使用由 TeamFlos 提供的 Phira 線上服務部分之前，你必須閱讀並同意我們的《服務條款》和《隱私政策》。
-tos = 服務條款
-policy = 隱私政策
+tos-and-policy-desc = 在使用由 TeamFlos 提供的 Phira 線上服務部分之前，你必須 *點擊此處* 閱讀並同意我們的《服務條款》和《隱私政策》。
+tos-deny = 拒絕
+tos-accept = 同意
 
 open-in-web = 在網站中打開

--- a/phira/locales/zh-TW/home.ftl
+++ b/phira/locales/zh-TW/home.ftl
@@ -7,3 +7,10 @@ not-opened = 敬請期待
 not-logged-in = 未登入
 
 failed-to-update = 載入使用者資訊失敗
+
+update = v{ $version } 更新
+update-desc =
+  時間：{ $date }
+  描述：{ $desc }
+update-ignore = 忽略該版本
+update-go = 更新

--- a/phira/locales/zh-TW/profile.ftl
+++ b/phira/locales/zh-TW/profile.ftl
@@ -15,6 +15,5 @@ uploading-avatar = 頭像上傳中...
 load-record-failed = 載入遊玩紀錄失敗
 
 last-login = 上次登入於：{ $time }
-
 badge-admin = 管理員
 badge-sponsor = 贊助者

--- a/phira/locales/zh-TW/rate.ftl
+++ b/phira/locales/zh-TW/rate.ftl
@@ -3,7 +3,7 @@ rate = 評分
 filter = 按評分篩選
 
 cancel = 取消
-confirm = 確認
+confirm = 確定
 
 lower-bound = 最低評分
 upper-bound = 最高評分

--- a/phira/locales/zh-TW/settings.ftl
+++ b/phira/locales/zh-TW/settings.ftl
@@ -27,7 +27,7 @@ item-sfx = 音效音量
 item-bgm = BGM 音量
 item-cali = 調整延遲
 
-item-show-acc = 顯示實時準度
+item-show-acc = 顯示實時準確率
 item-dc-pause = 雙擊暫停
 item-dhint = 雙押提示
 item-dhint-sub = 同時觸線的音符將會被高亮

--- a/phira/locales/zh-TW/song.ftl
+++ b/phira/locales/zh-TW/song.ftl
@@ -38,10 +38,15 @@ edit-saved = 保存成功
 edit-preview-invalid = 預覽時間超出範圍
 edit-tags = 編輯標籤
 edit-downloaded = 您無法編輯下載的譜面！
+edit-overwrite = 覆蓋
+edit-overwrite-confirm = 確定要使用外部的譜面覆蓋當前的譜面嗎？（只有在點擊"更新"後才會同步到線上平臺）
+edit-overwrite-success = 覆蓋成功
+edit-overwrite-failed = 覆蓋失敗
 
 edit-upload = 上傳
 edit-update = 更新
 
+upload-not-saved = 你尚未保存譜面，確定要繼續上傳嗎？
 upload-login-first = 請先登入
 upload-builtin = 不能上傳內置譜面
 upload-rules = 上傳須知
@@ -52,12 +57,11 @@ upload-rules-content =
   3. 譜面內容（包括音樂、插圖、文字等）須符合中華人民共和國其他法律與法規，不得違法或包含不良信息
   4. 上傳者上傳即同意譜面可用於 Phira 的公開宣傳，其他方式利用仍需譜師許可
   5. 本須知最終解釋權歸 TeamFlos 所有
-upload-cancel = 再想想
-upload-confirm = 確認上傳
 uploading = 上傳中...
 upload-chart-failed = 上傳譜面失敗
 upload-success = 上傳成功，請等待審核！
 upload-failed = 上傳失敗
+upload-confirm-clear-ldb = 由於當前譜面文件和遠端譜面文件不同，上傳譜面後將清空該譜面的排行榜，確定要繼續嗎？
 
 ldb = 排行榜
 ldb-load-failed = 載入排行榜失敗

--- a/phira/locales/zh-TW/tags.ftl
+++ b/phira/locales/zh-TW/tags.ftl
@@ -8,7 +8,7 @@ wanted = 想包含的標籤
 unwanted = 不想包含的標籤
 
 cancel = 取消
-confirm = 確認
+confirm = 確定
 
 filter-by-rating = 按評分篩選
 

--- a/prpr/locales/zh-TW/ending.ftl
+++ b/prpr/locales/zh-TW/ending.ftl
@@ -1,4 +1,13 @@
 
+retry = 重試
+proceed = 繼續
+
+new-best = 新紀錄
+max-combo = 最大連擊數
+rks-delta = RKS變化
+accuracy = 準確率
+error = 誤差
+
 uploading = 上傳成績中...
 uploaded = 成績上傳成功
 upload-failed = 成績上傳失敗


### PR DESCRIPTION
本PR包括：添加自 2c31e2bb0da74c0f613a15ba854bcf5d2098df55 至 4d4a003b2bbc3550f2effc17a78b7cbaac47d916 的繁體中文翻譯(zh-TW)、改善過往翻譯、去除非統一空行

### 非繁簡替換
#### 新增

- 確認(與取消併用 且呈 如 `按鈕` 形式等 者) -> 確定
- 最高連擊 -> 最大連擊數
- 你確定要 -> 確定要
- 已覆盖 -> 覆蓋成功

#### 變更
- 准度/準度 -> 準確率

### 待考量項目(未實裝):
- 誤差 -> 平均差/標準差 
> 這涉及到[源代碼部分](https://github.com/TeamFlos/phira/blob/b82e123eb103f5af3372e6c7c8ac766b534c2171/prpr/src/scene/ending.rs#L346C37-L346C37)，雖然寫的是 `std` 但感覺還是看下比較準(畢竟有 `ldb-std = 無瑕度`)，由於目前我找不到 `PlayerResult` 的 `std` 是如何變化的，故此變化代定
