### PR TITLE
fix: unexpected hitsound at the end of hold note in autoplay mode

### DIFF
--- a/prpr/src/judge.rs
+++ b/prpr/src/judge.rs
@@ -866,7 +866,9 @@ impl Judge {
             res.with_model(line.now_transform(res, &chart.lines) * note_transform, |res| {
                 res.emit_at_origin(line.notes[id as usize].rotation(&line), res.res_pack.info.fx_perfect())
             });
-            note_hitsound.play(res);
+            if !matches!(chart.lines[line_id].notes[id as usize].kind, NoteKind::Hold { .. }) {
+                note_hitsound.play(res);
+            }
         }
     }
 


### PR DESCRIPTION
After updating to v0.6.3, hitsound will also be triggered at the end of the Hold note.

<sub>Feel free to close this PR, hope the code have no exceptions except for fake note and hold note</sub>