### PR TITLE
fix: use linear filter for note texture to prevent blur

### DIFF
--- a/prpr/src/core/resource.rs
+++ b/prpr/src/core/resource.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use anyhow::{bail, Context, Result};
 use macroquad::prelude::*;
-use miniquad::{gl::GLuint, Texture, TextureWrap};
+use miniquad::{gl::{GLuint, GL_LINEAR}, Texture, TextureWrap};
 use sasa::{AudioClip, AudioManager, Sfx};
 use serde::Deserialize;
 use std::{
@@ -175,7 +175,7 @@ impl ResourcePack {
     pub async fn load(fs: &mut dyn FileSystem) -> Result<Self> {
         macro_rules! load_tex {
             ($path:literal) => {
-                SafeTexture::from(image::load_from_memory(&fs.load_file($path).await.with_context(|| format!("Missing {}", $path))?)?).with_mipmap()
+                SafeTexture::from(image::load_from_memory(&fs.load_file($path).await.with_context(|| format!("Missing {}", $path))?)?).with_filter(GL_LINEAR)
             };
         }
         let info: ResPackInfo = serde_yaml::from_str(&String::from_utf8(fs.load_file("info.yml").await.context("Missing info.yml")?)?)?;

--- a/prpr/src/ext.rs
+++ b/prpr/src/ext.rs
@@ -12,7 +12,7 @@ use lyon::{
     path::{builder::BorderRadii, Path, Winding},
 };
 use macroquad::prelude::*;
-use miniquad::{BlendFactor, BlendState, BlendValue, CompareFunc, Equation, PrimitiveType, StencilFaceState, StencilOp, StencilState};
+use miniquad::{gl::GLenum, BlendFactor, BlendState, BlendValue, CompareFunc, Equation, PrimitiveType, StencilFaceState, StencilOp, StencilState};
 use once_cell::sync::Lazy;
 use ordered_float::{Float, NotNan};
 use sasa::AudioManager;
@@ -106,6 +106,17 @@ impl SafeTexture {
             glBindTexture(GL_TEXTURE_2D, id);
             glGenerateMipmap(GL_TEXTURE_2D);
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR as _);
+        }
+        self
+    }
+
+    pub fn with_filter(self, filter: GLenum) -> Self{
+        let id = self.0 .0.raw_miniquad_texture_handle().gl_internal_id();
+        unsafe {
+            use miniquad::gl::*;
+            glBindTexture(GL_TEXTURE_2D, id);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, filter as _);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, filter as _);
         }
         self
     }


### PR DESCRIPTION
Hold texture with mipmap will be blurred if mipmap filter is used

# Comparison
- before:
![d31434738d28d9c531367f37b7187e54](https://github.com/user-attachments/assets/b47b654d-220c-4177-9df7-54b98e1365b5)
- after:
![3d05b5c612d4a38a1e5fde63adb0fe40](https://github.com/user-attachments/assets/fade05cc-4709-4e00-a431-cae0d9c5ae23)
