### PR TITLE
chore: update `ahash` to `0.8.7`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,9 +46,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
 dependencies = [
  "cfg-if",
  "getrandom",

--- a/prpr/Cargo.toml
+++ b/prpr/Cargo.toml
@@ -70,7 +70,7 @@ colored = { version = "=2.0.0", optional = true }
 
 prpr-avc = { path = "../prpr-avc", optional = true }
 
-ahash = "=0.8.6"
+ahash = "=0.8.7"
 cfg-expr = "=0.15.4"
 system-deps = "=6.1.2"
 


### PR DESCRIPTION
I tried building Phira for my environment, but it fails.
Because in latest Rust toolchain, `stdsimd` feature no longer exists.
This patch seems working well in my environment (succeed building and executing), and it'll work in other environments.
My environment is macOS aarch64.

(However, ahash version is specified at 8095e6895fea1af9098d7d815b2c0c3fdbbe1e9b. This's my concern; does additional context exist?)