### PR TITLE
fix: the feature local_key_cell_methods has been stable since 1.73.0 and no longer requires an attribute to enable

### DIFF
--- a/prpr/src/lib.rs
+++ b/prpr/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(local_key_cell_methods)]
 
 pub mod bin;
 pub mod config;

--- a/prpr/src/lib.rs
+++ b/prpr/src/lib.rs
@@ -1,4 +1,3 @@
-
 pub mod bin;
 pub mod config;
 pub mod core;


### PR DESCRIPTION
编译项目时发现
![2024-12-10_22-14-07](https://github.com/user-attachments/assets/27f3668a-b93c-4b99-ba22-c136472a5f71)
尝试直接删掉，编译成功
![2024-12-10_22-13-44](https://github.com/user-attachments/assets/0ba14bbc-b9f7-4447-a88f-17a5710b4c54)
