### PR TITLE
Fix chromatic.glsl

### DIFF
--- a/prpr/src/core/shaders/chromatic.glsl
+++ b/prpr/src/core/shaders/chromatic.glsl
@@ -18,7 +18,7 @@ void main() {
   vec3 c = vec3(0.0);
   vec2 offset = (uv - vec2(0.5)) * vec2(1, -1);
   int sample_count = int(sampleCount);
-  for (int i = 0; i < 4; ++i) {
+  for (int i = 0; i < 64; ++i) {
     if (i >= sample_count) break;
     float t = 2.0 * float(i) / float(sample_count - 1); // range 0.0->2.0
     vec3 slice = vec3(1.0 - t, 1.0 - abs(t - 1.0), t - 1.0);


### PR DESCRIPTION
`sampleCount` can only go up to 3 in the original code, which differs from both the [comment](https://github.com/TeamFlos/phira/blob/c7b03784840f81ea3567e43245848063a2abe01b/prpr/src/core/shaders/chromatic.glsl#L8) and the [doc](https://teamflos.github.io/phira-docs/chart-standard/extra/effect/builtin/chromatic.html).