### PR TITLE
fix anys gateway删除无法使用的默认anys网关

### DIFF
--- a/phira/src/data.rs
+++ b/phira/src/data.rs
@@ -67,7 +67,7 @@ pub struct LocalChart {
 }
 
 fn default_anys_gateway() -> String {
-    "https://anys.mivik.moe".to_string()
+    "".to_string()
 }
 
 #[derive(Default, Serialize, Deserialize)]


### PR DESCRIPTION
 具体参考问题 #495 
默认anys网关为https://anys.mivik.moe
但是此anys网关已无法连接
所～以，我把他从默认anys网关删掉了
如果使用此anys网关可能导致无法加载歌曲预览，这对萌新是很不友好的
其实只是想混个pr，我根本不懂rust
awa