### PR TITLE
perf: optimize performance for charts with lots of large textures

### DIFF
--- a/prpr/src/core/line.rs
+++ b/prpr/src/core/line.rs
@@ -242,7 +242,7 @@ impl JudgeLine {
                     JudgeLineKind::Texture(texture, _) => {
                         let mut color = color.unwrap_or(WHITE);
                         color.a = alpha.max(0.0);
-                        if (color.a - 0.).abs() > 0.01 {
+                        if !(color.a == 0.0) {
                             let hf = vec2(texture.width(), texture.height());
                             draw_texture_ex(
                                 **texture,

--- a/prpr/src/core/line.rs
+++ b/prpr/src/core/line.rs
@@ -242,20 +242,21 @@ impl JudgeLine {
                     JudgeLineKind::Texture(texture, _) => {
                         let mut color = color.unwrap_or(WHITE);
                         color.a = alpha.max(0.0);
-                        if !(color.a == 0.0) {
-                            let hf = vec2(texture.width(), texture.height());
-                            draw_texture_ex(
-                                **texture,
-                                -hf.x / 2.,
-                                -hf.y / 2.,
-                                color,
-                                DrawTextureParams {
-                                    dest_size: Some(hf),
-                                    flip_y: true,
-                                    ..Default::default()
-                                },
-                            );
+                        if color.a == 0.0 {
+                            return;
                         }
+                        let hf = vec2(texture.width(), texture.height());
+                        draw_texture_ex(
+                            **texture,
+                            -hf.x / 2.,
+                            -hf.y / 2.,
+                            color,
+                            DrawTextureParams {
+                                dest_size: Some(hf),
+                                flip_y: true,
+                                ..Default::default()
+                            },
+                        );
                     }
                     JudgeLineKind::TextureGif(anim, frames, _) => {
                         let t = anim.now_opt().unwrap_or(0.0);

--- a/prpr/src/core/line.rs
+++ b/prpr/src/core/line.rs
@@ -242,18 +242,20 @@ impl JudgeLine {
                     JudgeLineKind::Texture(texture, _) => {
                         let mut color = color.unwrap_or(WHITE);
                         color.a = alpha.max(0.0);
-                        let hf = vec2(texture.width(), texture.height());
-                        draw_texture_ex(
-                            **texture,
-                            -hf.x / 2.,
-                            -hf.y / 2.,
-                            color,
-                            DrawTextureParams {
-                                dest_size: Some(hf),
-                                flip_y: true,
-                                ..Default::default()
-                            },
-                        );
+                        if (color.a - 0.).abs() > 0.01 {
+                            let hf = vec2(texture.width(), texture.height());
+                            draw_texture_ex(
+                                **texture,
+                                -hf.x / 2.,
+                                -hf.y / 2.,
+                                color,
+                                DrawTextureParams {
+                                    dest_size: Some(hf),
+                                    flip_y: true,
+                                    ..Default::default()
+                                },
+                            );
+                        }
                     }
                     JudgeLineKind::TextureGif(anim, frames, _) => {
                         let t = anim.now_opt().unwrap_or(0.0);

--- a/prpr/src/parse/rpe.rs
+++ b/prpr/src/parse/rpe.rs
@@ -426,8 +426,8 @@ async fn parse_judge_line(
     fs: &mut dyn FileSystem,
     bezier_map: &BezierMap,
     hitsounds: &mut HitSoundMap,
+    line_texture_map: &mut HashMap<String, SafeTexture>,
 ) -> Result<JudgeLine> {
-    let line_texture_map: HashMap<String, SafeTexture> = Default::default();
     let event_layers: Vec<_> = rpe.event_layers.into_iter().flatten().collect();
     fn events_with_factor(
         r: &mut BpmList,
@@ -551,29 +551,37 @@ async fn parse_judge_line(
                 JudgeLineKind::TextureGif(events, frames, rpe.texture.clone())
             } else {
                 if let Some(texture) = line_texture_map.get(&rpe.texture) {
+                    debug!(
+                        "texture {} reused, id: {}",
+                        rpe.texture.clone(),
+                        texture.clone().into_inner().raw_miniquad_texture_handle().gl_internal_id()
+                    );
                     JudgeLineKind::Texture(texture.clone(), rpe.texture.clone())
                 } else {
-                    JudgeLineKind::Texture(
-                        SafeTexture::from(image::load_from_memory(
-                            &fs.load_file(&rpe.texture)
-                                .await
-                                .with_context(|| ptl!("illustration-load-failed", "path" => rpe.texture.clone()))?,
-                        )?)
-                        .with_mipmap(),
-                        rpe.texture.clone(),
-                    )
+                    let texture = SafeTexture::from(image::load_from_memory(
+                        &fs.load_file(&rpe.texture)
+                            .await
+                            .with_context(|| ptl!("illustration-load-failed", "path" => rpe.texture.clone()))?,
+                    )?)
+                    .with_mipmap();
+                    line_texture_map.insert(rpe.texture.clone(), texture.clone());
+                    JudgeLineKind::Texture(texture, rpe.texture.clone())
                 }
             }
         } else {
-            JudgeLineKind::Texture(
-                SafeTexture::from(image::load_from_memory(
+            if let Some(texture) = line_texture_map.get(&rpe.texture) {
+                debug!("texture {} reused, id: {}", rpe.texture.clone(), texture.clone().into_inner().raw_miniquad_texture_handle().gl_internal_id());
+                JudgeLineKind::Texture(texture.clone(), rpe.texture.clone())
+            } else {
+                let texture = SafeTexture::from(image::load_from_memory(
                     &fs.load_file(&rpe.texture)
                         .await
                         .with_context(|| ptl!("illustration-load-failed", "path" => rpe.texture.clone()))?,
                 )?)
-                .with_mipmap(),
-                rpe.texture.clone(),
-            )
+                .with_mipmap();
+                line_texture_map.insert(rpe.texture.clone(), texture.clone());
+                JudgeLineKind::Texture(texture, rpe.texture.clone())
+            }
         },
         color: if let Some(events) = rpe.extended.as_ref().and_then(|e| e.color_events.as_ref()) {
             parse_events(r, events, Some(WHITE), bezier_map).with_context(|| ptl!("color-events-parse-failed"))?
@@ -669,10 +677,11 @@ pub async fn parse_rpe(source: &str, fs: &mut dyn FileSystem, extra: ChartExtra)
         .max().unwrap_or_default() + 1.;
     // don't want to add a whole crate for a mere join_all...
     let mut lines = Vec::new();
+    let mut line_texture_map = HashMap::new();
     for (id, rpe) in rpe.judge_line_list.into_iter().enumerate() {
         let name = rpe.name.clone();
         lines.push(
-            parse_judge_line(&mut r, rpe, max_time, fs, &bezier_map, &mut hitsounds)
+            parse_judge_line(&mut r, rpe, max_time, fs, &bezier_map, &mut hitsounds, &mut line_texture_map)
                 .await
                 .with_context(move || ptl!("judge-line-location-name", "jlid" => id, "name" => name))?,
         );


### PR DESCRIPTION
share identical texture across lines to save memory use (potential fps boost by avoiding context switch)
avoid drawing texture when the line is transparent (alpha <= 0.01)

fps performance before this pr: (release build, chart #35849)
![image](https://github.com/user-attachments/assets/c287325b-723c-4a2e-858f-144282aba693)

fps performance after this pr: (release build, chart #35849)
![image](https://github.com/user-attachments/assets/bbbcaade-d86f-4d65-9b6b-358a54967879)
