### PR TITLE
fix: particle

### DIFF
--- a/prpr/src/core/resource.rs
+++ b/prpr/src/core/resource.rs
@@ -245,10 +245,10 @@ impl ResourcePack {
 }
 
 pub struct ParticleEmitter {
-    scale: f32,
-    emitter: Emitter,
-    emitter_square: Emitter,
-    hide_particles: bool,
+    pub scale: f32,
+    pub emitter: Emitter,
+    pub emitter_square: Emitter,
+    pub hide_particles: bool,
 }
 
 impl ParticleEmitter {

--- a/prpr/src/scene/game.rs
+++ b/prpr/src/scene/game.rs
@@ -818,6 +818,17 @@ impl Scene for GameScene {
                     }
                     tm.now() as f32
                 } else {
+                    #[cfg(target_os = "windows")]
+                    { // wtf bro. why must particles exist on Windows?
+                        let emitter_config = self.res.emitter.emitter.config.clone();
+                        let emitter_square_config = self.res.emitter.emitter_square.config.clone();
+                        self.res.emitter.emitter.config.size = 0.0;
+                        self.res.emitter.emitter_square.config.size = 0.0;
+                        self.res.emitter.emitter.emit(vec2(0.0, 0.0), 1);
+                        self.res.emitter.emitter_square.emit(vec2(0.0, 0.0), 1);
+                        self.res.emitter.emitter.config = emitter_config;
+                        self.res.emitter.emitter_square.config = emitter_square_config;
+                    }
                     self.res.alpha = 1. - (1. - time / Self::BEFORE_TIME).powi(3);
                     if self.mode == GameMode::Exercise {
                         self.exercise_range.start


### PR DESCRIPTION
修复 Windows 下没有存在过粒子时的渲染问题
wtf bro. why must particles exist on Windows?