### PR TITLE
fix: correct UTF-8 char boundary calculation in text truncation

### DIFF
--- a/prpr/src/ui/text.rs
+++ b/prpr/src/ui/text.rs
@@ -176,10 +176,7 @@ impl<'a, 's, 'ui> DrawText<'a, 's, 'ui> {
             let st = if index == 0 { 0. } else { end(&glyphs[index - 1]) };
             let byte_index = if index == 0 { 0 } else { glyphs[index - 1].byte_index };
             // Round to char boundary
-            let byte_index = text.as_bytes()[byte_index.saturating_sub(3)..byte_index]
-                .iter()
-                .rposition(|b| (*b as i8) >= -0x40)
-                .unwrap();
+            let byte_index = text[..byte_index].char_indices().next_back().map_or(0, |(i, _)| i);
             return (
                 section.with_text(vec![
                     Text::new(&text[..byte_index])


### PR DESCRIPTION
fix: correct UTF-8 char boundary calculation in text truncation