### PR TITLE
fix: fix null-check logic method call error

### DIFF
--- a/prpr/src/parse/rpe.rs
+++ b/prpr/src/parse/rpe.rs
@@ -473,7 +473,8 @@ async fn parse_judge_line(
                                         && rpe
                                             .extended
                                             .as_ref()
-                                            .is_none_or(|it| it.text_events.as_ref().is_none_or(|it| it.is_empty()))
+                                            .and_then(|it| it.text_events.as_ref())
+                                            .is_none_or(|it| it.is_empty())
                                         && rpe.attach_ui.is_none()
                                     {
                                         0.5


### PR DESCRIPTION
In the current mainline version, the pause button displays abnormally (e.g., for ID=16624), and there are rendering glitches in the latter half of the chart. I reverted to the previous code, and it works fine