### PR TITLE
chore(l10n): Make Turkish Selectable

### DIFF
--- a/prpr-l10n/src/lib.rs
+++ b/prpr-l10n/src/lib.rs
@@ -27,6 +27,7 @@ langs! {
     "pt-BR": "Português",
     "ru-RU": "Русский",
     "th-TH": "แบบไทย",
+    "tr-TR": "Türkçe",
     "vi-VN": "Tiếng Việt",
     "zh-CN": "简体中文",
     "zh-TW": "繁體中文"


### PR DESCRIPTION
### Language Info

**Tag:** tr-TR [^1]
**Name:** Türkçe [^2]
**Translation Strings:** #289
**Latest Translation is Based on:** v0.6.2

### Checklist [^3]

- [ ] Check Translation Strings (?)
- [ ] Test on built binary
  - [x] Phira OSS + x86_64-pc-windows-gnu
- [ ] Check and Update `bold.ttf` [^4]



[^1]: [Subtag Checker](https://r12a.github.io/app-subtags/) and [W3 Choose A Language Tag](https://www.w3.org/International/questions/qa-choosing-language-tags) may be useful
[^2]: Used in [Wiktionary](https://en.wikipedia.org/wiki/Wikipedia:List_of_Wiktionaries#:~:text=T%C3%BCrk%C3%A7e) and [Microsoft](https://www.microsoft.com/en-us/locale#:~:text=T%C3%BCrk%C3%A7e)
[^3]: No longer need to modify language count in `prpr-l10n/src/tools.rs` since `#614 de-DE`
[^4]: Sorry for submitting this PR after the bold.ttf was just updated 🛐 