### PR TITLE
fix(l10n): Add fallback (en-US) and zh translations for item-fullscreen, Remove item-fullscreen-sub

### DIFF
--- a/phira/locales/en-US/settings.ftl
+++ b/phira/locales/en-US/settings.ftl
@@ -9,7 +9,6 @@ about = Info
 
 item-lang = Language
 item-fullscreen = Fullscreen Mode
-item-fullscreen-sub = Fill the entire screen.
 item-offline = Offline Mode
 item-offline-sub = Disable all online functionality.
 item-server-status = Server Status

--- a/phira/locales/zh-CN/settings.ftl
+++ b/phira/locales/zh-CN/settings.ftl
@@ -9,7 +9,6 @@ about = 关于
 
 item-lang = 语言
 item-fullscreen = 全屏模式
-item-fullscreen-sub = 铺满整个屏幕
 item-offline = 离线模式
 item-offline-sub = 在离线模式下将不能上传成绩
 item-server-status = 服务器状态

--- a/phira/locales/zh-TW/settings.ftl
+++ b/phira/locales/zh-TW/settings.ftl
@@ -9,7 +9,6 @@ about = 關於
 
 item-lang = 語言
 item-fullscreen = 全螢幕模式
-item-fullscreen-sub = 填滿整個螢幕
 item-offline = 離線模式
 item-offline-sub = 離線模式下無法上傳成績
 item-server-status = 伺服器狀態

--- a/phira/src/page/settings.rs
+++ b/phira/src/page/settings.rs
@@ -471,7 +471,7 @@ impl GeneralList {
 
         #[cfg(target_os = "windows")]
         item! {
-            render_title(ui, tl!("item-fullscreen"), Some(tl!("item-fullscreen-sub")));
+            render_title(ui, tl!("item-fullscreen"), None);
             render_switch(ui, rr, t, &mut self.fullscreen_btn, config.fullscreen_mode);
         }
 


### PR DESCRIPTION
### Issue

Since #478 was merged, the terminal will flood with these messages with Windows build.
This will interfere with viewing useful log.
Even if zh_CN is defined on #619, the warnings are still made, while your locale setting is not zh_CN
The actual fallback language is en_US
```log
2025-12-31T11:05:20.261179200Z  WARN prpr_l10n::local: no translation found for item-fullscreen, returning key
2025-12-31T11:05:20.261522300Z  WARN prpr_l10n::local: no translation found for item-fullscreen-sub, returning key
```
#### Test Method
For tester who don't use Chinese (Simplified, People's Republic of China) (zh_CN), just build it.
For Chinese (China) tester, change your system language
Or run Phira (with Linux Fullscreen Supported) with this command <sup>*[Unix/Linux only, not including targets for Android, all os from Apple][?](https://stackoverflow.com/questions/76480789/rust-is-there-a-list-of-what-target-is-a-member-of-what-target-family) [untested]*</sup>
```sh
LANGUAGE=zh_TW LC_ALL=zh_TW LC_MESSAGES=zh_TW LANG=zh_TW cargo run ...
```
See also the [[source code]](https://github.com/1Password/sys-locale/blob/main/src/lib.rs) of `sys-locale`.

### Changes

This PR adds en_US (fallback language) to fix the issue.
Also, include the zh_TW translation, which primarily maintained by me

*Maybe different if maintainer changed it. Please refer to the “Files changed” tab.*
| Key | en-US | zh-CN | zh-TW |
|---|---|---|---|
| `item-fullscreen` | Fullscreen Mode | 全屏模式 | 全螢幕模式 |
| `item-fullscreen-sub` | Fill the entire screen. | 铺满整个屏幕 | 填滿整個螢幕[^1] |

zh-CN translation is extracted and followed from #619 by [fhscey](https://github.com/fhscey) *(author marked)*



[^1]: 我嘗試翻譯過了...
先說後面那個「屏幕」，候選包括：「畫面」、「螢幕」，目標是顯示設備的可顯示部分，因此不包含「顯示器」
接著是「铺满」，候選字詞與不選用原因包括：
（此處參考全螢幕的某種動畫表現：擴張到占滿整個螢幕）
「鋪滿」：與「平面」有關是個加分項，但我覺得更像是把多個小東西完全覆蓋在某個平面上，而且音近「撲滿」
「填滿」：把空間/洞/空缺/空白處填滿，hmm...反正[Google結果](https://www.google.com/search?q=%22%E5%A1%AB%E6%BB%BF%E6%95%B4%E5%80%8B%E8%9E%A2%E5%B9%95%22+-site%3Awww.reddit.com+-site%3Amicrosoft.com+-site%3A*.cn+-site%3Aalibabacloud.com&lr=lang_zh-TW&client=firefox-b-d&hs=rHJp&sca_esv=b10f18a3cc6747ea&biw=1920&bih=1087&tbs=lr%3Alang_1zh-TW&ei=56WHafmZBI_c1e8PjZqnyQE&ved=0ahUKEwi5qeSZociSAxUPbvUHHQ3NKRkQ4dUDCBM&uact=5&oq=%22%E5%A1%AB%E6%BB%BF%E6%95%B4%E5%80%8B%E8%9E%A2%E5%B9%95%22+-site%3Awww.reddit.com+-site%3Amicrosoft.com+-site%3A*.cn+-site%3Aalibabacloud.com&gs_lp=Egxnd3Mtd2l6LXNlcnAiXyLloavmu7_mlbTlgIvonqLluZUiIC1zaXRlOnd3dy5yZWRkaXQuY29tIC1zaXRlOm1pY3Jvc29mdC5jb20gLXNpdGU6Ki5jbiAtc2l0ZTphbGliYWJhY2xvdWQuY29tSJ-OA1C_-QJY84wDcAF4AJABAJgBsAGgAaAHqgEDMS42uAEDyAEA-AEC-AEBmAIAoAIAmAMAiAYBkgcAoAflArIHALgHAMIHAMgHAIAIAA&sclient=gws-wiz-serp)看起來最多就選它好了
「塞滿」：聽起來也很像多個小東西填滿容器，而且可能有空隙
「瀰漫」：不是氣體也不是抽象的東西
「充斥」：有不好的東西在一個大空間的感覺
「充滿」：頂多說「填充」，「充滿」可能更常用在抽象的東西上（比如：氛圍）
「占有」/「佔有」/「佔據」：聽起來像是位居高處，Phira 對玩家喊：「現在你的電腦由我掌控」。另外，其實你按 Windows 鍵，下面的東西還是會蓋過
「展開」、「填充」、「擴大」、「張開」：要麼是單純的動詞，要麼通常情況下只是比原來大，而不是螢幕畫面的任何地方都有遊戲畫面的身影
「最大化」：這通常還保有視窗邊框
當然更多字也不是不行，在正體中文這種密集文字中，短文字相比上方更大的標題有點弱，暫時先忠實原作者翻譯吧...
當然也想過自己從零開始寫：
大致可用元素包括：「沉浸」、「沐浴」、「沉浸感」、「沉浸式體驗」、「更好的遊戲體驗」、「無邊框」、「大畫面」
怎麽組都怪怪的，比如「沉浸式體驗」感覺誇大到 VR 領域去了、「無邊框」會跟 Borderless Mode 混淆嗎(Osu Lazer 有的)
其中給朋友審的一個奇怪翻譯是「沉浸在不受視覺干擾的節拍之中」，「視覺干擾」原意是為了區別於「聽覺享受」，但也是被認為奇怪的點，或許這裡就不該填「節奏」/「節拍」，但加「遊戲」、「音遊」又聽起來很弱
然後可選地還要對不知道「全螢幕」是什麼的有益，要麼描述現象或視覺回饋，要麼描述開全螢幕的目的或原因
或許要廣告專業的來吧，我國文和表達能力爛到爆，問AI也沒救回(就還是很怪，可能我的理想目標收斂了)，先這樣吧