### PR TITLE
fix/perf(avg-fps): Paused duration shouldn't be counted in the total time for AVG FPS & Remove unused frame record if show_avg_fps is disabled

### DIFF
--- a/prpr/src/scene/game.rs
+++ b/prpr/src/scene/game.rs
@@ -1088,13 +1088,15 @@ impl Scene for GameScene {
     }
 
     fn render(&mut self, tm: &mut TimeManager, ui: &mut Ui) -> Result<()> {
-        let current_time = tm.real_time();
-        if matches!(self.state, State::Playing) && !tm.paused() {
-            let frame_delta = current_time - self.fps_last_frame_time;
-            self.fps_total_time += frame_delta;
-            self.fps_frame_count += 1;
+        if self.res.config.show_avg_fps {
+            let current_time = tm.real_time();
+            if matches!(self.state, State::Playing) && !tm.paused() {
+                let frame_delta = current_time - self.fps_last_frame_time;
+                self.fps_total_time += frame_delta;
+                self.fps_frame_count += 1;
+            }
+            self.fps_last_frame_time = current_time;
         }
-        self.fps_last_frame_time = current_time;
 
         let res = &mut self.res;
         let asp = ui.viewport.2 as f32 / ui.viewport.3 as f32;


### PR DESCRIPTION
See previous changes in #642 to enhance something like ~~overflow prevention~~

### Reproduce

- Start Game
- Pause 3~4 min (maybe go to toilet or someone call you)
- Resume
- Final AVG FPS. Drop: 143.3 -> 62.2

### Original

```rs
if matches!(self.state, State::Playing) && !tm.paused() {
    let current_time = tm.real_time();
    // the last frame time is the frame before pause
    // resumed time - before pause = any long duration
    let frame_delta = current_time - self.fps_last_frame_time;
    self.fps_last_frame_time = current_time;
    self.fps_total_time += frame_delta;
    self.fps_frame_count += 1;
}
```

### Solution

```rs
// macro_rules! reset {
//    $self.fps_frame_count = 0;
//    $self.fps_total_time = 0.0;
//    $self.fps_last_frame_time = $tm.real_time();  // fps_last_frame_time should be reset as real_time here
// }

// Still record fps_last_frame_time
let current_time = tm.real_time();
if matches!(self.state, State::Playing) && !tm.paused() {  // This fix also prevent State edge cases
    // current - (old) fps_last_frame_time = still got 1 frame if resumed
    let frame_delta = current_time - self.fps_last_frame_time;
    self.fps_total_time += frame_delta;
    self.fps_frame_count += 1;
}
self.fps_last_frame_time = current_time;  // new fps_last_frame_time (current)
```

### Extra Performance Fix

Because
- `show_avg_fps` is just hide the final average calculation, but not stop the frame counting
- The `real_time()` and calculation will do every frames
- Add an if-block can prevent variable pollution

I add `if self.res.config.show_avg_fps` block
or I don't know why show_avg_fps is a toggle option
