### PR TITLE
fix(l10n): the l10n key "invalid-time" should not be "invalid time"

### DIFF
--- a/prpr/src/ui/chart_info.rs
+++ b/prpr/src/ui/chart_info.rs
@@ -111,8 +111,8 @@ pub fn render_chart_info(ui: &mut Ui, edit: &mut ChartInfoEdit, width: f32) -> (
             edit.updated = true;
             match || -> Result<(f32, f32), Cow<'static, str>> {
                 let (st, en) = string.split_once(['-', '—']).ok_or_else(|| tl!("illegal-input"))?;
-                let st = parse_time(st.trim()).ok_or_else(|| tl!("invalid time"))?;
-                let en = parse_time(en.trim()).ok_or_else(|| tl!("invalid time"))?;
+                let st = parse_time(st.trim()).ok_or_else(|| tl!("invalid-time"))?;
+                let en = parse_time(en.trim()).ok_or_else(|| tl!("invalid-time"))?;
                 if st + 1. > en {
                     return Err(tl!("preview-too-short"));
                 }


### PR DESCRIPTION
Fluent key shouldn't contains a space
I only test space issue on other keys (in phira crate)
just return key and output warning message "no translation found"

### Before

<img width="975" height="640" alt="Show 'invalid time' instead of the translated text" src="https://github.com/user-attachments/assets/f50cd9ca-f004-43fb-a20b-3aa112a37468" />
