### PR TITLE
chore(l10n,zh-TW,add): Sync new translations

### DIFF
--- a/phira/locales/zh-TW/song.ftl
+++ b/phira/locales/zh-TW/song.ftl
@@ -46,6 +46,8 @@ edit-overwrite-failed = 覆蓋失敗
 edit-upload = 上傳
 edit-update = 更新
 
+warn = 警告
+cancel-not-saved = 譜面資訊尚未儲存，確定要取消變更嗎？
 upload-not-saved = 你尚未儲存譜面，確定要繼續上傳嗎？
 upload-login-first = 請先登入
 upload-builtin = 不能上傳內建譜面


### PR DESCRIPTION
## Comparison

| en-US | zh-CN | zh-TW | Context |
|---|---|---|---|
| Warning | 警告 | 警告 | Title of "Chart hasn't been saved yet, would you like to exit now?" |
| Chart hasn't been saved yet, would you like to exit now? | 你还没有保存信息，确定要退出吗？ | 譜面資訊尚未儲存，確定要取消變更嗎？ | Charter might accidentally click on areas outside the "Edit Chart" panel after changing chart information, or press the cancel button, which the chart is silently unchanged. This dialog box will hint the condition. |

<sub>有一种在刷PR的感觉😓</sub>