### PR TITLE
chore(l10n): Sync zh-TW translations

### DIFF
--- a/phira/locales/zh-TW/settings.ftl
+++ b/phira/locales/zh-TW/settings.ftl
@@ -85,7 +85,7 @@ about-content =
   運維
   { $operations }
 
-  文檔
+  說明文件
   { $documentation }
 
   美術
@@ -97,10 +97,10 @@ about-content =
   音效
   { $audio }
 
-  社區管理
+  社群管理
   { $community }
 
-  本地化
+  在地化
   { $localization }
 
   以及許多志願譜面審核員！完整列表參見 https://phira.moe/staff


### PR DESCRIPTION
#### AP/FC Indicator

```fluent
item-ap-fc-indicator = AP/FC 指示器
item-ap-fc-indicator-sub = 以判定線顏色呈現 All Perfect / Full Combo 狀態
```

結算的 PERFECT 和 MAX COMBO 足以指涉對象了
加上 All 和 Full 是國中小 1200 單字Lv1,Lv2，故不翻
確實掙扎考慮過 全連(擊/打/段)/全接/全良/滿分/收歌/全PERFECT 等都算不同遊戲玩家間的術語
或許大部分無助於讓新接觸的玩家懂在說什麼，還影響閱讀流暢度(應該大部分都是音遊人?)
故選擇標英文全名就好

#### Use Keyboard

https://github.com/TeamFlos/phira/blob/3907fb72ad9e1a159f84b939af827df316f6a96e/phira/locales/zh-TW/settings.ftl#L54-L55
Reviewed https://github.com/TeamFlos/phira/commit/3907fb72ad9e1a159f84b939af827df316f6a96e , lgtm

#### Reduce Motion
https://github.com/TeamFlos/phira/blob/5dbf2cdb7ff25c1a003677ab276c433f916867d0/phira/locales/zh-TW/settings.ftl#L56-L57

Reviewed https://github.com/TeamFlos/phira/commit/5dbf2cdb7ff25c1a003677ab276c433f916867d0 , lgtm

#### Staff List https://github.com/TeamFlos/phira/commit/5a6babd52319c7f45309e191a0be8acad92defa9

| en-US | zh-CN | zh-TW | Context |
|---|---|---|---|
| Documentation | 文档 | 說明文件[^4] |  |
| Community | 社区[^1] | 社群 | Online Commnity, such as Discord, QQ |
| Localization | 本地化 | 在地化[^2] | In phira, localization is usually to translate to adapt culture and way of expression in the specific region. |
| Operations | 运维 | 運維[^3] | Operation & Maintenance |


[^1]: [社区 (网络科学术语) - 百度百科](https://baike.baidu.com/item/%E7%A4%BE%E5%8C%BA/54979023)
[^2]: 既然 [Google論壇](https://groups.google.com/g/chinese-l10n/c/Z3Rkg6_h5PM) 在吵「本地化」是否通用，是否該與 zh-CN 區分，那在地化跟本土化選一個吧！[維基百科](https://zh.wikipedia.org/zh-tw/%E6%9C%AC%E5%9C%9F%E5%8C%96#%E4%B8%AD%E6%96%87%E8%AF%AD%E5%A2%83%E4%B8%AD%E7%9A%84%E6%9C%AF%E8%AF%AD%E5%B7%AE%E5%BC%82) 提及了「本土化」的另一個意思(臺灣本土化運動，[翰林](https://www.ehanlin.com.tw/app/keyword/%E5%9C%8B%E4%B8%AD/%E6%AD%B7%E5%8F%B2/%E6%9C%AC%E5%9C%9F%E5%8C%96.html)更將其解之「去中國化」)，故選擇「在地化」
[^3]: 「維運」和「運維」在 [Google Trend](https://trends.google.com/explore?q=%25E7%25B6%25AD%25E9%2581%258B%2C%25E9%2581%258B%25E7%25B6%25AD&date=all&geo=TW) 上呈五五波，儘管[樂詞網](https://terms.naer.edu.tw/search/?csrfmiddlewaretoken=UwR431saiImDNEoj8tHFvnI6jTVt547Irq5LOce2EVz1UJP0TzlN3PWOCf0gLRmd&match_type=phrase&query_op=&query_field=title&query_term=%E7%B6%AD%E9%81%8B&filter_term=&filter_field=&filter_op=&filter_bool=&filter_term=&filter_field=&filter_op=&filter_bool=&filter_term=&filter_field=&filter_op=&filter_bool=&filter_term=&filter_field=&filter_op=&filter_bool=&filter_term=&filter_field=&filter_op=&filter_bool=)更偏好「維運」，就不特別修改了
[^4]: [Translate Wiki](https://translatewiki.net/wiki/Portal:Zh/Glossary#:~:text=documentdocumentation) 與 [笨他](https://invade.tw/v/%E6%96%87%E6%AA%94) 記錄了「文檔」對應臺灣的「文件」(無論是 Document 或是 Documentation) ，然只說「文件」無法區分意思，此處依 [Google](https://firebase.google.com/docs?hl=zh-tw), [Python](https://docs.python.org/zh-tw/3.14/), [Amazon](https://docs.aws.amazon.com/zh_tw/) 等譯為「說明文件」，也算是某人常常指正的一個詞了...