### PR TITLE
fix: respack id boundary check

### DIFF
--- a/phira/src/data.rs
+++ b/phira/src/data.rs
@@ -262,7 +262,7 @@ impl Data {
             }
             self.respacks.push(filename);
         }
-        self.respack_id = self.respack_id.min(self.respacks.len().saturating_sub(1));
+        self.respack_id = self.respack_id.min(self.respacks.len());
         if let Some(res_pack_path) = &mut self.config.res_pack_path {
             if res_pack_path.starts_with('/') {
                 // for compatibility


### PR DESCRIPTION
`respack_id` 0 is reserved for internal default resource packs, so the maximum `respack_id` should be equal to `respacks.len()`

The issue occurs when restarting the game after selecting the last resource pack in the list