### PR TITLE
fix: extra respack id boundary check

### DIFF
--- a/phira/src/page/respack.rs
+++ b/phira/src/page/respack.rs
@@ -118,9 +118,14 @@ impl ResPackPage {
                 }
             })
             .collect();
-        save_data()?;
 
-        let index = get_data().respack_id;
+        let respack_id = get_data().respack_id;
+        let index = respack_id.min(items.len().saturating_sub(1));
+        if index != respack_id {
+            data.respack_id = index;
+        }
+
+        save_data()?;
         items[index].load();
         let delete_btn = DRectButton::new().with_delta(-0.004).with_elevation(0.);
         Ok(Self {


### PR DESCRIPTION
Added a new boundary check for respack to prevent index out of bounds errors when the respack is corrupted

[log.txt](https://github.com/user-attachments/files/26538518/log.txt)
