### PR TITLE
chore(l10n): add item-show-avg-fps-sub

### DIFF
--- a/phira/locales/en-US/settings.ftl
+++ b/phira/locales/en-US/settings.ftl
@@ -46,6 +46,7 @@ item-audio-buffer-size = Audio Buffer Size
 
 item-show-acc = Real-Time Accuracy
 item-show-avg-fps = Show AVG FPS
+item-show-avg-fps-sub = Display the average FPS on the results screen.
 item-ap-fc-indicator = AP/FC Indicator
 item-ap-fc-indicator-sub = Use line color to indicate AP/FC status.
 item-dc-pause = Double-Tap to Pause
@@ -104,4 +105,3 @@ about-content =
   { $localization }
 
   And many more voluntary chart reviewers. For a full list please refer to https://phira.moe/staff .
-

--- a/phira/locales/zh-CN/settings.ftl
+++ b/phira/locales/zh-CN/settings.ftl
@@ -46,6 +46,7 @@ item-audio-buffer-size = 音频缓冲区大小
 
 item-show-acc = 显示实时准度
 item-show-avg-fps = 显示平均帧率
+item-show-avg-fps-sub = 在结算界面显示平均帧率
 item-ap-fc-indicator = AP/FC（全完美/全连）指示器
 item-ap-fc-indicator-sub = 使用判定线颜色显示全 AP/FC 状态
 item-dc-pause = 双击暂停

--- a/phira/locales/zh-TW/settings.ftl
+++ b/phira/locales/zh-TW/settings.ftl
@@ -41,6 +41,7 @@ preferred-sample-rate-default = 系統預設
 item-audio-buffer-size = 音訊緩衝區大小
 item-show-acc = 顯示即時準確率
 item-show-avg-fps = 顯示平均FPS
+item-show-avg-fps-sub = 在結算介面顯示每秒影格數
 item-dc-pause = 點兩下暫停
 item-dhint = 雙押提示
 item-dhint-sub = 同時觸線的音符將會被高亮

--- a/phira/src/page/settings.rs
+++ b/phira/src/page/settings.rs
@@ -904,7 +904,7 @@ impl ChartList {
             render_switch(ui, rr, t, &mut self.ap_fc_indicator_btn, config.ap_fc_indicator);
         }
         item! {
-            render_title(ui, tl!("item-show-avg-fps"), None);
+            render_title(ui, tl!("item-show-avg-fps"), Some(tl!("item-show-avg-fps-sub")));
             render_switch(ui, rr, t, &mut self.show_avg_fps_btn, config.show_avg_fps);
         }
         item! {


### PR DESCRIPTION
可能会误解成实时帧率显示，此PR在sub补充是在结算界面
暂时没想到什么好点子直接在 title 插入结算的语义
难道...「结算显示平均帧率」？看官方怎么决定了，有其他想法直接 closed 吧