### PR TITLE
fix: preserve last modified time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5845,6 +5845,7 @@ version = "8.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a243cfad17427fc077f529da5a95abe4e94fd2bfdb601611870a6557cc67657"
 dependencies = [
+ "chrono",
  "crc32fast",
  "flate2",
  "indexmap",

--- a/phira/Cargo.toml
+++ b/phira/Cargo.toml
@@ -75,7 +75,7 @@ tokio = { workspace = true, features = ["rt-multi-thread", "sync"] }
 tracing = { workspace = true }
 uuid = { workspace = true, features = ["v4", "serde"] }
 walkdir = { workspace = true }
-zip = { workspace = true }
+zip = { workspace = true, features = ["chrono"] }
 zstd = "0.13"
 
 miniquad = { workspace = true }

--- a/phira/src/page/library.rs
+++ b/phira/src/page/library.rs
@@ -1257,7 +1257,8 @@ impl Page for LibraryPage {
                 let mut zip = zip::ZipWriter::new(BufWriter::new(output));
                 let options = zip::write::SimpleFileOptions::default()
                     .compression_method(zip::CompressionMethod::Stored)
-                    .unix_permissions(0o755);
+                    .unix_permissions(0o755)
+                    .last_modified_time(chrono::Utc::now().naive_utc().try_into().unwrap_or_default());
                 for (i, name) in paths.iter().enumerate() {
                     zip.start_file(format!("{name}.zip"), options)?;
                     let mut chart_bytes = Vec::new();

--- a/phira/src/scene/song.rs
+++ b/phira/src/scene/song.rs
@@ -2873,12 +2873,18 @@ pub fn compress_folder<W: Write + Seek>(src: &Path, dst: &mut W) -> Result<()> {
         let entry = entry?;
         let path = entry.path();
         let name = path.strip_prefix(src)?;
+        let mod_time = entry
+            .metadata()
+            .ok()
+            .and_then(|m| m.modified().ok())
+            .map(|t| DateTime::<Utc>::from(t).naive_utc())
+            .unwrap_or_else(|| Utc::now().naive_utc());
         if path.is_file() {
-            zip.start_file_from_path(name, options)?;
+            zip.start_file_from_path(name, options.last_modified_time(mod_time.try_into().unwrap_or_default()))?;
             let mut f = File::open(path)?;
             std::io::copy(&mut f, &mut zip)?;
         } else if !name.as_os_str().is_empty() {
-            zip.add_directory_from_path(name, options)?;
+            zip.add_directory_from_path(name, options.last_modified_time(mod_time.try_into().unwrap_or_default()))?;
         }
     }
     zip.finish()?;


### PR DESCRIPTION
Close #746
Close #761

### Changes and Choice

- files in chart will keep its own last modified time.
- zip by multi-export will all be seen as the same time as top-level zip. (the time before zipping)
- Enable `chrono` feature of `zip`
- Use `chrono` feature for `zip`, instead of `time` currently due to crate addition and complexity
  - `SystemTime` may have no existing method to convert to `zip::DateTime`
  - `impl chrono::NaiveDateTime for zip::Datetime` is only available if `chrono` feature is enabled
  - `chrono` feature won't set modified time as "current timestamp". That is only `time` feature would do.
- Consider see also: https://github.com/zip-rs/zip2/issues/219

### NOTICE

- `chrono` feature also add logic with `std::fs::File::set_modified` on `zip::read::ZipArchive::extract` ([src](https://github.com/zip-rs/zip2/blob/399469e20081561089c4fbb63574d4a8942ec752/src/read.rs#L1016-L1022)). I'm not sure if there are some OS allows to write but deny write metadata. Currently, Phira using their custom logic (not `extract`), and the last modified time is still import time. It may still cause unavailablility for what we don't need in the future, so may need to remember it. (even if it's difficult to handle completely)

### BTW

There is a maybe unused function about writing zip. It had used on Mivik/prpr.
I just keep it original.

https://github.com/TeamFlos/phira/blob/15903cd7988f28c4427328d80293310374316b70/prpr/src/fs.rs#L22