### PR TITLE
732 unlock fix

### DIFF
--- a/phira/src/scene/song.rs
+++ b/phira/src/scene/song.rs
@@ -784,7 +784,7 @@ impl SongScene {
                 .charts
                 .iter()
                 .find(|it| it.local_path == *local_path)
-                .is_some_and(|it| it.played_unlock)
+                .is_some_and(|it| it.info.has_unlock && it.played_unlock)
             {
                 self.menu_options.push("unlock");
             }

--- a/phira/src/scene/unlock.rs
+++ b/phira/src/scene/unlock.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use macroquad::prelude::*;
 use prpr::{
     config::Config,
@@ -55,7 +55,8 @@ impl UnlockScene {
     ) -> Result<UnlockScene> {
         let bytes = fs
             .load_file(&info.unlock_video.clone().unwrap_or_else(|| "unlock.mp4".to_owned()))
-            .await?;
+            .await
+            .context("Cannot find unlock video file!")?;
         let video = Video::new(bytes, 0., ScaleType::Inside, Anim::new(vec![Keyframe::new(0., 1., 0)]), Anim::default())?;
         let clip = demux_audio(video.video_file().path().to_str().unwrap())?;
         let music_length = clip.as_ref().map_or(0., AudioClip::length);

--- a/prpr/src/ui/chart_info.rs
+++ b/prpr/src/ui/chart_info.rs
@@ -246,6 +246,7 @@ pub fn render_chart_info(ui: &mut Ui, edit: &mut ChartInfoEdit, width: f32) -> (
                     edit.enable_unlock = false;
                 } else {
                     info.unlock_video = Some("unlock.mp4".to_string());
+                    edit.unlock_video = Some("unlock.mp4".to_string());
                     edit.enable_unlock = true;
                 }
                 edit.updated = true;


### PR DESCRIPTION
#732 
- 增加了找不到解锁动画文件的报错信息；
- 修改谱面信息，勾选或重新勾选”启用解锁动画“选择框时，设置默认不存在的文件路径（可能存在），在漏设解锁动画文件保存时报错；
- 已播放解锁动画再禁用解锁动画时，在菜单栏隐藏”播放解锁动画“选项。

之前若解锁动画使用默认“unlock.mp4”文件名，“启用解锁动画“可以反复勾选。该修复合并后将不能随意开关”启用解锁动画，每次重新勾选”启用解锁动画“时需要重新选择解锁动画的视频文件，否则无法保存修改。