### PR TITLE
fix: resume TimeManager when GameScene exit

### DIFF
--- a/prpr/src/scene/game.rs
+++ b/prpr/src/scene/game.rs
@@ -1306,6 +1306,9 @@ impl Scene for GameScene {
                 GameMode::TweakOffset => NextScene::PopWithResult(Box::new(None::<f32>)),
             }
         } else if let Some(next_scene) = self.next_scene.take() {
+            if !matches!(next_scene, NextScene::None) {
+                tm.resume();
+            }
             tm.speed = 1.0;
             tm.adjust_time = false;
             next_scene

--- a/prpr/src/scene/game.rs
+++ b/prpr/src/scene/game.rs
@@ -1306,7 +1306,7 @@ impl Scene for GameScene {
                 GameMode::TweakOffset => NextScene::PopWithResult(Box::new(None::<f32>)),
             }
         } else if let Some(next_scene) = self.next_scene.take() {
-            if !matches!(next_scene, NextScene::None) {
+            if !matches!(next_scene, NextScene::None) && tm.paused() {
                 tm.resume();
             }
             tm.speed = 1.0;


### PR DESCRIPTION
##  相关Issue
#822 

## 修复方式
当GameScene通过除should_exit外方式退出时恢复TimeManager