### PR TITLE
chore: update staff list

### DIFF
--- a/phira/staff.yml
+++ b/phira/staff.yml
@@ -14,6 +14,7 @@ development:
 - Navinatte
 - NuanRMxi
 - ParaN3xus
+- Pimeng
 - sjfhsjfh
 - sparrowhe
 - void-cat-0

--- a/phira/staff.yml
+++ b/phira/staff.yml
@@ -3,10 +3,12 @@ development:
 - fhscey
 - HLMC
 - IcedDog
+- K0nGbawa
 - Libcine
 - Licapule
 - liquidhelium
 - ljlVink
+- lRENyaaa
 - Mivik
 - Naptie
 - Navinatte
@@ -60,10 +62,11 @@ localization:
   de-DE: [TwitchLawlx]
   id-ID: [nekoken, RzaIX]
   ja-JP: [kosuke14, rei0403r]
-  ko-KR: [CHOUMnote, DominoKorean]
+  ko-KR: [CHOUMnote, Chart-ic, DominoKorean]
+  mn-MN: [b114514]
   pl-PL: [SumarΣxon]
   pt-BR: [riosukisan]
-  ru-RU: [Reenouneer, SomeMiscUser]
+  ru-RU: [Reenouneer, SomeMiscUser, Springstreak]
   th-TH: [Mishiranuuuuu]
   zh-TW: [Licapule, Limefruit1, YuevUwU]
   tr-TR: [NandeMD]

--- a/phira/staff.yml
+++ b/phira/staff.yml
@@ -1,9 +1,11 @@
 development:
 - ChickenPige0n
+- F-Unction
 - fhscey
 - HLMC
 - IcedDog
 - K0nGbawa
+- KisaragiEffective
 - Libcine
 - Licapule
 - liquidhelium
@@ -17,6 +19,7 @@ development:
 - Pimeng
 - sjfhsjfh
 - sparrowhe
+- typed-sigterm
 - void-cat-0
 - YuevUwU
 
@@ -30,6 +33,7 @@ documentation:
 - fzso5071
 - HLMC
 - HosinoEJ
+- JIAZIYI007
 - liquidhelium
 - ljlVink
 - MAX3957
@@ -71,4 +75,4 @@ localization:
   th-TH: [Mishiranuuuuu]
   zh-TW: [Licapule, Limefruit1, YuevUwU]
   tr-TR: [NandeMD]
-  vi-VN: [kenichiakasuki, natelyt12]
+  vi-VN: [kenichiakasuki, natelyt12, Vanilla6770]


### PR DESCRIPTION
**Currently Based on:** https://github.com/TeamFlos/phira/compare/5a6babd52319c7f45309e191a0be8acad92defa9...3eff3bcc605b5c84504ba8e321a34c9d23f2a331 (roughly since v0.7.0-rc1)
**Current Criterion:** the person who authored the commit exists in the main branch during this period.

### Portal to what they contributed

Dev: [K0nGbawa](https://github.com/TeamFlos/phira/commits/main/?author=K0nGbawa), [lRENyaaa](https://github.com/TeamFlos/phira/commits/main/?author=lRENyaaa), [Pimeng](https://github.com/TeamFlos/phira/commits/main/?author=Pimeng)
L10n: [Chart-ic](https://github.com/TeamFlos/phira/commits/main/?author=Chart-ic), [b114514](https://github.com/TeamFlos/phira/commits/main/?author=b114514), [Springstreak](https://github.com/TeamFlos/phira/commits/main/?author=Springstreak)

### Note

- Not including Claude and Weblate yet. This depends on author's opinion.
- Not sure the order of l10n keys. `mn-MN` is added in this PR
- If author already plans to update this list regularly, this PR can be ignored.