### PR TITLE
feat: add drag/flick early tap judgment protection

### DIFF
--- a/prpr/src/judge.rs
+++ b/prpr/src/judge.rs
@@ -609,10 +609,14 @@ impl Judge {
                         dt
                     };
                     let key = dt + (dist / NOTE_WIDTH_RATIO_BASE - 1.).max(0.) * DIST_FACTOR;
-                    let key = if matches!(note.kind, NoteKind::Click | NoteKind::Hold { .. })
-                        && note.time > t
-                        && max_protection_time.is_some_and(|prot_time| (t - prot_time) / spd < (note.time - t) / spd - PROTECTION_THRESHOLD)
-                    {
+let key = if matches!(note.kind, NoteKind::Click | NoteKind::Hold { .. })
+    && note.time > t
+    && max_protection_time.is_some_and(|prot_time| (t - prot_time) < (note.time - t) - PROTECTION_THRESHOLD)
+{
+    f64::INFINITY
+} else {
+    key
+};
                         f64::INFINITY
                     } else {
                         key

--- a/prpr/src/judge.rs
+++ b/prpr/src/judge.rs
@@ -609,14 +609,10 @@ impl Judge {
                         dt
                     };
                     let key = dt + (dist / NOTE_WIDTH_RATIO_BASE - 1.).max(0.) * DIST_FACTOR;
-let key = if matches!(note.kind, NoteKind::Click | NoteKind::Hold { .. })
-    && note.time > t
-    && max_protection_time.is_some_and(|prot_time| (t - prot_time) < (note.time - t) - PROTECTION_THRESHOLD)
-{
-    f64::INFINITY
-} else {
-    key
-};
+                    let key = if matches!(note.kind, NoteKind::Click | NoteKind::Hold { .. })
+                        && note.time > t
+                        && max_protection_time.is_some_and(|prot_time| (t - prot_time) / spd < (note.time - t) / spd - PROTECTION_THRESHOLD)
+                    {
                         f64::INFINITY
                     } else {
                         key

--- a/prpr/src/judge.rs
+++ b/prpr/src/judge.rs
@@ -20,6 +20,7 @@ pub const FLICK_SPEED_THRESHOLD: f32 = 0.8;
 pub const LIMIT_PERFECT: f64 = 0.08;
 pub const LIMIT_GOOD: f64 = 0.16;
 pub const LIMIT_BAD: f64 = 0.22;
+pub const PROTECTION_THRESHOLD: f64 = 0.01;
 pub const UP_TOLERANCE: f64 = 0.05;
 pub const DIST_FACTOR: f64 = 0.2;
 
@@ -560,6 +561,18 @@ impl Judge {
                 continue;
             }
             let t = time_of(touch);
+            let mut max_protection_time: Option<f64> = None;
+            for (line, (idx, st)) in chart.lines.iter().zip(self.notes.iter()) {
+                for &note_idx in &idx[*st..] {
+                    let note = &line.notes[note_idx as usize];
+                    if matches!(note.kind, NoteKind::Drag | NoteKind::Flick)
+                        && note.time < t
+                        && matches!(note.judge, JudgeStatus::NotJudged)
+                    {
+                        max_protection_time = Some(max_protection_time.map_or(note.time, |m| m.max(note.time)));
+                    }
+                }
+            }
             let mut closest = (None, X_DIFF_MAX, LIMIT_BAD, LIMIT_BAD + (X_DIFF_MAX / NOTE_WIDTH_RATIO_BASE - 1.).max(0.) * DIST_FACTOR);
             for (line_id, ((line, pos), (idx, st))) in chart.lines.iter_mut().zip(pos.iter()).zip(self.notes.iter_mut()).enumerate() {
                 let Some(pos) = pos[id] else {
@@ -599,6 +612,16 @@ impl Judge {
                         dt
                     };
                     let key = dt + (dist / NOTE_WIDTH_RATIO_BASE - 1.).max(0.) * DIST_FACTOR;
+                    let key = if matches!(note.kind, NoteKind::Click | NoteKind::Hold { .. })
+                        && note.time > t
+                        && max_protection_time.is_some_and(|prot_time| {
+                            (t - prot_time) / spd < (note.time - t) / spd - PROTECTION_THRESHOLD
+                        })
+                    {
+                        f64::INFINITY
+                    } else {
+                        key
+                    };
                     if key < closest.3 {
                         closest = (Some((line_id, *id)), dist, dt, key);
                     }
@@ -612,10 +635,10 @@ impl Judge {
                 }
                 if click {
                     // click & hold
-                    let note = &mut line.notes[id as usize];
-                    if matches!(note.kind, NoteKind::Flick) {
+                    if matches!(line.notes[id as usize].kind, NoteKind::Flick) {
                         continue; // to next loop
                     }
+                    let note = &mut line.notes[id as usize];
                     if dt <= LIMIT_GOOD || matches!(note.kind, NoteKind::Hold { .. }) {
                         match note.kind {
                             NoteKind::Click => {

--- a/prpr/src/judge.rs
+++ b/prpr/src/judge.rs
@@ -565,10 +565,7 @@ impl Judge {
             for (line, (idx, st)) in chart.lines.iter().zip(self.notes.iter()) {
                 for &note_idx in &idx[*st..] {
                     let note = &line.notes[note_idx as usize];
-                    if matches!(note.kind, NoteKind::Drag | NoteKind::Flick)
-                        && note.time < t
-                        && matches!(note.judge, JudgeStatus::NotJudged)
-                    {
+                    if matches!(note.kind, NoteKind::Drag | NoteKind::Flick) && note.time < t && matches!(note.judge, JudgeStatus::NotJudged) {
                         max_protection_time = Some(max_protection_time.map_or(note.time, |m| m.max(note.time)));
                     }
                 }
@@ -614,9 +611,7 @@ impl Judge {
                     let key = dt + (dist / NOTE_WIDTH_RATIO_BASE - 1.).max(0.) * DIST_FACTOR;
                     let key = if matches!(note.kind, NoteKind::Click | NoteKind::Hold { .. })
                         && note.time > t
-                        && max_protection_time.is_some_and(|prot_time| {
-                            (t - prot_time) / spd < (note.time - t) / spd - PROTECTION_THRESHOLD
-                        })
+                        && max_protection_time.is_some_and(|prot_time| (t - prot_time) / spd < (note.time - t) / spd - PROTECTION_THRESHOLD)
                     {
                         f64::INFINITY
                     } else {


### PR DESCRIPTION
## 概述

参考官方 Phigros 判定机制，增加 Drag/Flick 早按保护，避免误触后续蓝键。

参考资料：[关于Phigros判定](https://www.bilibili.com/opus/1226031520301449218)

## 实现内容

- 当 Drag/Flick 已经过判定线但尚未被判定时，保护后续的 Click/Hold 不被早按误触
- 保护触发条件：Drag/Flick 比 Click/Hold 更靠近判定线至少 **0.01 秒**（官方阈值）
- 实现方式：在 closest 匹配阶段，将被保护的 Click/Hold 的匹配权重设为 `INFINITY`，使其不会被选中
- 仅保护 early 侧（尚未到达判定线）的 Click/Hold，late 侧不受影响

## 判定逻辑示意

<img width="967" height="559" alt="judgment protection logic 1" src="https://github.com/user-attachments/assets/1397fd56-274d-4745-bf33-cef474c9ed56" />

<img width="961" height="280" alt="judgment protection logic 2" src="https://github.com/user-attachments/assets/6b5ee82e-7d16-4160-95ba-f3cb59dcbb06" />

## 改动文件

- `prpr/src/judge.rs`：新增 `PROTECTION_THRESHOLD` 常量、保护时间预处理、匹配阶段权重调整

## 测试情况

- [x] 编译通过
- [x] 普通单键/多押判定正常（未受保护影响）
- [x] Drag/Flick 早按保护生效，不会误触后续蓝键
- [x] `cargo fmt --all --check` 通过
